### PR TITLE
feat: add all common nullable value for spanner and reorder

### DIFF
--- a/generator/funcs.go
+++ b/generator/funcs.go
@@ -630,12 +630,16 @@ func (a *Generator) nullcheck(field *internal.Field) string {
 	paramName := a.goparamname(field.Name)
 
 	switch field.Type {
-	case "spanner.NullInt64",
-		"spanner.NullString",
+	case "spanner.NullBool",
+		"spanner.NullDate",
+		"spanner.NullFloat32",
 		"spanner.NullFloat64",
-		"spanner.NullBool",
-		"spanner.NullTime",
-		"spanner.NullDate":
+		"spanner.NullInt64",
+		"spanner.NullInterval",
+		"spanner.NullJSON",
+		"spanner.NullNumeric",
+		"spanner.NullString",
+		"spanner.NullTime":
 		return fmt.Sprintf("%s.IsNull()", paramName)
 	}
 

--- a/v2/generator/funcs.go
+++ b/v2/generator/funcs.go
@@ -420,12 +420,16 @@ func (a *Generator) nullcheck(field *models.Field) string {
 	paramName := a.goParam(field.Name)
 
 	switch field.Type {
-	case "spanner.NullInt64",
-		"spanner.NullString",
+	case "spanner.NullBool",
+		"spanner.NullDate",
+		"spanner.NullFloat32",
 		"spanner.NullFloat64",
-		"spanner.NullBool",
-		"spanner.NullTime",
-		"spanner.NullDate":
+		"spanner.NullInt64",
+		"spanner.NullInterval",
+		"spanner.NullJSON",
+		"spanner.NullNumeric",
+		"spanner.NullString",
+		"spanner.NullTime":
 		return fmt.Sprintf("%s.IsNull()", paramName)
 	}
 


### PR DESCRIPTION
without this change, the nullnumberic will generate the wrong nil check:
```
---	if transactionAmount.IsNull() {
+++	if yo, ok := transactionAmount.(yoIsNull); ok && yo.IsNull() {
 		conds[4] = "TransactionAmount IS NULL"
```