### PR TITLE
fix: Support resolving primary keys through nested views

### DIFF
--- a/loaders/parser.go
+++ b/loaders/parser.go
@@ -232,13 +232,23 @@ func (s *SpannerLoaderFromDDL) primaryKeyColumnList(table string) ([]*models.Ind
 		return nil, nil
 	}
 
-	// lookup PK for read-only view
-	if tbl.createView != nil {
+	// Walk the view chain to find the underlying base table.
+	visited := map[string]struct{}{}
+	for tbl.createView != nil {
+		if _, seen := visited[table]; seen {
+			return nil, fmt.Errorf("circular view reference detected at %q", table)
+		}
+		visited[table] = struct{}{}
+
 		sourceTable, err := baseTablesForViewDDL(tbl.createView.SQL())
 		if err != nil {
 			return nil, err
 		}
-		tbl = s.tables[firstOrDefault(sourceTable)]
+		table = firstOrDefault(sourceTable)
+		tbl, ok = s.tables[table]
+		if !ok {
+			return nil, nil
+		}
 	}
 
 	var cols []*models.IndexColumn

--- a/loaders/parser_test.go
+++ b/loaders/parser_test.go
@@ -1,6 +1,8 @@
 package loaders
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -21,6 +23,7 @@ func Test_baseTableForViewDDL(t *testing.T) {
 			want:      []string{"FullTypes", "SecondTable"},
 		},
 	}
+
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			got, err := baseTablesForViewDDL(tt.ddlString)
@@ -33,4 +36,56 @@ func Test_baseTableForViewDDL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_primaryKeyColumnList(t *testing.T) {
+	t.Run("NestedViews", func(t *testing.T) {
+		loader := ddlLoader(t, `
+CREATE TABLE BaseTable (
+  AccountID STRING(36) NOT NULL
+) PRIMARY KEY (AccountID);
+
+CREATE VIEW Layer1 SQL SECURITY INVOKER AS
+  SELECT b.AccountID FROM BaseTable AS b;
+
+CREATE VIEW Layer2 SQL SECURITY INVOKER AS
+  SELECT l1.AccountID FROM Layer1 AS l1;`)
+
+		cols, err := loader.primaryKeyColumnList("Layer2")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{"AccountID"}
+		got := make([]string, len(cols))
+		for i, c := range cols {
+			got[i] = c.ColumnName
+		}
+		if diff := cmp.Diff(got, want); diff != "" {
+			t.Errorf("primaryKeyColumnList() (-got, +want)\n%s", diff)
+		}
+	})
+
+	t.Run("Error_CircularReference", func(t *testing.T) {
+		loader := ddlLoader(t, `
+CREATE VIEW ViewA SQL SECURITY INVOKER AS SELECT x FROM ViewB;
+CREATE VIEW ViewB SQL SECURITY INVOKER AS SELECT x FROM ViewA;`)
+
+		_, err := loader.primaryKeyColumnList("ViewA")
+		if err == nil {
+			t.Fatal("expected error for circular view reference, got nil")
+		}
+	})
+}
+
+func ddlLoader(t *testing.T, ddl string) *SpannerLoaderFromDDL {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "schema.sql")
+	if err := os.WriteFile(path, []byte(ddl), 0600); err != nil {
+		t.Fatal(err)
+	}
+	loader, err := NewSpannerLoaderFromDDL(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return loader
 }

--- a/loaders/spanner.go
+++ b/loaders/spanner.go
@@ -94,16 +94,34 @@ func (s *SpannerLoader) IndexList(table string) ([]*models.Index, error) {
 
 func (s *SpannerLoader) IndexColumnList(table string, index string) ([]*models.IndexColumn, error) {
 	if index == "PRIMARY_KEY" {
-		view, err := SpanView(s.client, table)
+		resolved, err := s.resolveToBaseTable(table, map[string]struct{}{})
 		if err != nil {
 			return nil, err
 		}
-		if view != nil {
-			return SpanIndexColumns(s.client, firstOrDefault(view.BaseTables), index)
+		if resolved != table {
+			return SpanIndexColumns(s.client, resolved, index)
 		}
 	}
 
 	return SpanIndexColumns(s.client, table, index)
+}
+
+// resolveToBaseTable walks the view chain until it finds a real table, guarding
+// against circular references.
+func (s *SpannerLoader) resolveToBaseTable(table string, visited map[string]struct{}) (string, error) {
+	if _, seen := visited[table]; seen {
+		return "", fmt.Errorf("circular view reference detected at %q", table)
+	}
+	visited[table] = struct{}{}
+
+	view, err := SpanView(s.client, table)
+	if err != nil {
+		return "", err
+	}
+	if view == nil {
+		return table, nil
+	}
+	return s.resolveToBaseTable(firstOrDefault(view.BaseTables), visited)
 }
 
 var lengthRegexp = regexp.MustCompile(`\(([0-9]+|MAX)\)$`)


### PR DESCRIPTION
## Overview

Both `SpannerLoader` and `SpannerLoaderFromDDL` only resolved one level of view indirection when looking up primary keys. If a view's base table was itself a view, the primary key lookup returned an empty slice, causing a panic.

This PR updates the logic to walk the view chain until it reaches a real table.